### PR TITLE
fix(aviso-tool): ignore self signed certificate errors

### DIFF
--- a/packages/aviso-tool/src/FakeYandexAvisoRequest.ts
+++ b/packages/aviso-tool/src/FakeYandexAvisoRequest.ts
@@ -1,12 +1,14 @@
-import crypto                            from 'crypto'
-import nodeFetch                         from 'node-fetch'
+import crypto                                   from 'crypto'
+import nodeFetch                                from 'node-fetch'
+import { Agent }                                from 'https'
 
-import { FakeYandexAvisoRequestOptions } from './interfaces'
+import { FakeYandexAvisoRequestOptions, Maybe } from './interfaces'
 
 export class FakeYandexAvisoRequest {
   public constructor(
     private readonly options: FakeYandexAvisoRequestOptions,
-    private readonly defaultParams: any
+    private readonly defaultParams: any,
+    private readonly customAgent: Maybe<Agent> = null
   ) {}
 
   public async execute() {
@@ -26,6 +28,7 @@ export class FakeYandexAvisoRequest {
         'Content-Type': 'application/json',
       },
       method: 'POST',
+      agent: this.customAgent,
     })
   }
 

--- a/packages/aviso-tool/src/index.ts
+++ b/packages/aviso-tool/src/index.ts
@@ -1,4 +1,6 @@
-import fs                         from 'fs'
+import { Agent }                  from 'https'
+import { readFileSync }           from 'fs'
+
 import { Command, flags }         from '@oclif/command'
 
 import { FakeYandexAvisoRequest } from './FakeYandexAvisoRequest'
@@ -37,14 +39,17 @@ class MakePurchaseCommand extends Command {
   }
 
   public async run() {
-    const parseOutput = this.parse(MakePurchaseCommand)
-
-    const { url, secret, purchaseId, orderSumAmount, filePath } = parseOutput.flags
+    const {
+      flags: { url, secret, purchaseId, orderSumAmount, filePath },
+    } = this.parse(MakePurchaseCommand)
 
     const requestParams = { url, secret, purchaseId, orderSumAmount }
-    const fakePayment = JSON.parse(fs.readFileSync(filePath, 'utf8'))
+    const fakePayment = JSON.parse(readFileSync(filePath, 'utf8'))
+    const agent = new Agent({ rejectUnauthorized: false })
 
-    await new FakeYandexAvisoRequest(requestParams, fakePayment).execute()
+    const fakeRequest = new FakeYandexAvisoRequest(requestParams, fakePayment, agent)
+
+    await fakeRequest.execute()
 
     this.log('💩 ОK!')
   }

--- a/packages/aviso-tool/src/interfaces.ts
+++ b/packages/aviso-tool/src/interfaces.ts
@@ -4,3 +4,5 @@ export interface FakeYandexAvisoRequestOptions {
   readonly purchaseId: number
   readonly orderSumAmount: number
 }
+
+export type Maybe<T> = T | null


### PR DESCRIPTION
affects: @atlantis-lab/yandex-aviso-tool

ISSUES CLOSED: #25